### PR TITLE
Add Zipcode Controller and Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -18,7 +18,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name="Getting Zipcodes")
+@Tag(name="Zip Code Information from http://www.zippopotam.us/")
 @Slf4j
 @RestController
 @RequestMapping("/api/zipcode")

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeController.java
@@ -1,9 +1,42 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Getting Zipcodes")
+@Slf4j
 @RestController
+@RequestMapping("/api/zipcode")
+
+
 public class ZipCodeController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    ZipCodeQueryService zipCodeQueryService;
+
+    @Operation(summary="Get information about a us zipcode", description ="JSON return format documented here: http://api.zippopotam.us/us/{zipcode}")
+    @GetMapping("/get")
+    public ResponseEntity<String> getZipCodes(
+        @Parameter(name="zipcode",description="Zipcode of Santa Barbara",example="93106") @RequestParam String zipcode
+    ) throws JsonProcessingException {
+        log.info("getZipCodes: zipcode={}", zipcode);
+        String result = zipCodeQueryService.getJSON(zipcode);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -16,7 +16,7 @@ public class ZipCodeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
        return "";

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -22,6 +22,7 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class ZipCodeQueryService {
 
+    ObjectMapper mapper = new ObjectMapper();
     private final RestTemplate restTemplate;
 
     public ZipCodeQueryService(RestTemplateBuilder restTemplateBuilder) {
@@ -37,10 +38,9 @@ public class ZipCodeQueryService {
         headers.setAccept(List.of(MediaType.APPLICATION_JSON));
         headers.setContentType(MediaType.APPLICATION_JSON);
 
-        HttpEntity<String> entity = new HttpEntity<>(headers);
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
 
-        //String ucsbLat = "34.4140"; // hard coded params for Storke Tower
-        //String ucsbLong = "-119.8489";
+        
         Map<String, String> uriVariables = Map.of("zipcode", zipcode);
 
         ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryService.java
@@ -1,12 +1,24 @@
 package edu.ucsb.cs156.spring.backenddemo.services;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.springframework.web.client.RestTemplate;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 
+@Slf4j
 @Service
 public class ZipCodeQueryService {
 
@@ -16,9 +28,25 @@ public class ZipCodeQueryService {
         restTemplate = restTemplateBuilder.build();
     }
 
+    
     public static final String ENDPOINT = "http://api.zippopotam.us/us/{zipcode}";
 
     public String getJSON(String zipcode) throws HttpClientErrorException {
-       return "";
+        log.info("zipcode={}", zipcode);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        //String ucsbLat = "34.4140"; // hard coded params for Storke Tower
+        //String ucsbLong = "-119.8489";
+        Map<String, String> uriVariables = Map.of("zipcode", zipcode);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
+
+
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/ZipCodeControllerTests.java
@@ -1,0 +1,52 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.ZipCodeQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = ZipCodeController.class)
+public class ZipCodeControllerTests {
+  private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  ZipCodeQueryService mockZipCodeQueryService;
+
+
+  @Test
+  public void test_getZipCodes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String zipcode = "93106";
+    when(mockZipCodeQueryService.getJSON(eq(zipcode))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/zipcode/get?zipcode=%s", zipcode);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/ZipCodeQueryServiceTests.java
@@ -1,0 +1,48 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+@RestClientTest(ZipCodeQueryService.class)
+public class ZipCodeQueryServiceTests {
+
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private ZipCodeQueryService ZipCodeQueryService;
+
+    
+    @Test
+    public void test_getJSON() {
+
+        String zipcode = "93106";
+        String expectedURL = ZipCodeQueryService.ENDPOINT.replace("{zipcode}", zipcode);
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = ZipCodeQueryService.getJSON(zipcode);
+        assertEquals(fakeJsonResult, actualResult);
+
+    }
+
+    
+    
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/zipcode/get` that can be used to get information
about the location of a particular zipcode.